### PR TITLE
Fix return context on empty baggage

### DIFF
--- a/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/propagation/CompositeTextMapPropagator.java
+++ b/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/propagation/CompositeTextMapPropagator.java
@@ -132,7 +132,7 @@ public class CompositeTextMapPropagator implements TextMapPropagator {
 			Context extractedContext = propagator.extract(context, carrier, getter);
 			Span span = Span.fromContextOrNull(extractedContext);
 			Baggage baggage = Baggage.fromContextOrNull(extractedContext);
-			if (span != null || baggage != null) {
+			if (span != null || (baggage != null && !baggage.isEmpty())) {
 				return extractedContext;
 			}
 		}


### PR DESCRIPTION
Baggage is always set in [this line](https://github.com/spring-projects-experimental/spring-cloud-sleuth-otel/blob/main/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/propagation/BaggageTextMapPropagator.java#L97), so it doesn't allow to disable it, if I use B3 propagation (it definetly [put](https://github.com/spring-projects-experimental/spring-cloud-sleuth-otel/blob/main/spring-cloud-sleuth-otel-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/otel/OtelPropagationConfiguration.java#L107) in context if I [use B3](https://github.com/spring-projects-experimental/spring-cloud-sleuth-otel/blob/main/spring-cloud-sleuth-otel-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/otel/OtelPropagationConfiguration.java#L126-L131))
So, it depends on the order of values in `spring.sleuth.propagation.type` property, which allows **only one type** of propagation, which goes the first.

For example, if I use `spring.sleuth.propagation.type: W3C, B3`, so it allows only W3C HTTP-headers, but not B3, and vice-versa if I use `spring.sleuth.propagation.type: B3, W3C` - it allows only B3 headers, but not W3C.